### PR TITLE
chore: prepare for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         "lab404/laravel-impersonate": "^1.7",
         "ladumor/laravel-pwa": "^0.0.2",
         "laminas/laminas-diactoros": "^2.6.0",
-        "laravel/framework": "^10.0",
-        "laravel/passport": "^11.8",
+        "laravel/framework": "^11.0",
+        "laravel/passport": "^12.0",
         "laravel/socialite": "^5.6",
         "laravel/telescope": "^5.0",
-        "laravel/tinker": "^2.8",
+        "laravel/tinker": "^2.9",
         "laravel/ui": "^4.2",
         "laravelcollective/html": "^6.3",
         "league/flysystem-aws-s3-v3": "^3.0",
@@ -48,10 +48,10 @@
         "barryvdh/laravel-ide-helper": "^2.13",
         "filp/whoops": "^2.13",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^9.5.10",
+        "nunomaduro/collision": "^8.0",
+        "phpunit/phpunit": "^10.5",
         "fakerphp/faker": "^1.9.1",
-        "spatie/laravel-ignition": "^2.0"
+        "spatie/laravel-ignition": "^3.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
## Summary
- bump Laravel framework to ^11.0 and update related dependencies
- adjust development tools for Laravel 11 compatibility

## Testing
- `composer update --no-progress --no-suggest --prefer-dist` *(fails: curl error 56 while downloading https://api.github.com/repos/vishalinfyom/coreui-templates: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf315fdb30832688e27031a5b6be9b