### PR TITLE
chore: update dependencies for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
         "laravel"
     ],
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/vishalinfyom/coreui-templates"
-        }
-    ],
     "require": {
         "php": "^8.2",
         "ext-json": "*",
@@ -23,7 +17,6 @@
         "firebase/php-jwt": "^6.4",
         "guzzlehttp/guzzle": "^7.2",
         "intervention/image": "^2.5",
-        "infyomlabs/laravel-generator": "^6.0",
         "lab404/laravel-impersonate": "^1.7",
         "ladumor/laravel-pwa": "^0.0.2",
         "laminas/laminas-diactoros": "^2.6.0",
@@ -32,16 +25,14 @@
         "laravel/socialite": "^5.6",
         "laravel/telescope": "^5.0",
         "laravel/tinker": "^2.9",
-        "laravel/ui": "^4.2",
-        "laravelcollective/html": "^6.3",
         "league/flysystem-aws-s3-v3": "^3.0",
-        "livewire/livewire": "^2.12",
+        "livewire/livewire": "^3.0",
         "mariuzzo/laravel-js-localization": "^1.9",
         "opcodesio/log-viewer": "^3.0",
         "pusher/pusher-php-server": "^7.0",
-        "spatie/laravel-permission": "^5.10",
+        "spatie/laravel-permission": "^6.0",
         "tightenco/ziggy": "^1.4",
-        "yajra/laravel-datatables-oracle": "^10.3"
+        "yajra/laravel-datatables-oracle": "^11.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8",
@@ -51,7 +42,7 @@
         "nunomaduro/collision": "^8.0",
         "phpunit/phpunit": "^10.5",
         "fakerphp/faker": "^1.9.1",
-        "spatie/laravel-ignition": "^3.0"
+        "spatie/laravel-ignition": "^2.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
## Summary
- drop unused InfyOm generator and legacy packages
- upgrade packages for Laravel 11 compatibility

## Testing
- `composer validate --no-check-lock`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf340fa3208326b94530b94a41037a