### PR TITLE
chore: remove Collective HTML service provider

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -193,7 +193,6 @@ return [
         /*
          * Package Service Providers...
          */
-        Collective\Html\HtmlServiceProvider::class,
         Laracasts\Flash\FlashServiceProvider::class,
         InfyOmGeneratorServiceProvider::class,
         // CoreUITemplatesServiceProvider::class,
@@ -228,8 +227,6 @@ return [
     'aliases' => Facade::defaultAliases()->merge([
         'DataTables' => Yajra\DataTables\Facades\DataTables::class,
         'Flash' => Laracasts\Flash\Flash::class,
-        'Form' => Collective\Html\FormFacade::class,
-        'Html' => Collective\Html\HtmlFacade::class,
         'Image' => Intervention\Image\Facades\Image::class,
         'OneSignal' => Berkayk\OneSignal\OneSignalFacade::class,
         'Redis' => Illuminate\Support\Facades\Redis::class,


### PR DESCRIPTION
## Summary
- remove leftover Collective\Html service provider
- drop Form/Html facade aliases

## Testing
- `composer install` *(fails: package versions in lock file do not satisfy constraints)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4863f35083268bf3a0b3e2b9ac96