### PR TITLE
Add internal flash messaging implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "classmap": [
+            "packages/flash/src"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/packages/flash/src/Flash.php
+++ b/packages/flash/src/Flash.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laracasts\Flash;
+
+use Illuminate\Support\Facades\Facade;
+
+class Flash extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'flash';
+    }
+}

--- a/packages/flash/src/FlashNotifier.php
+++ b/packages/flash/src/FlashNotifier.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laracasts\Flash;
+
+use Illuminate\Session\Store;
+
+class FlashNotifier
+{
+    /**
+     * The session store implementation.
+     */
+    protected Store $session;
+
+    public function __construct(Store $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Flash a general message to the session.
+     */
+    public function message(string $message, string $level = 'info'): void
+    {
+        $this->session->flash('flash_notification', [
+            'message' => $message,
+            'level' => $level,
+        ]);
+    }
+
+    /**
+     * Flash an information message.
+     */
+    public function info(string $message): void
+    {
+        $this->message($message, 'info');
+    }
+
+    /**
+     * Flash a success message.
+     */
+    public function success(string $message): void
+    {
+        $this->message($message, 'success');
+    }
+
+    /**
+     * Flash an error message.
+     */
+    public function error(string $message): void
+    {
+        $this->message($message, 'danger');
+    }
+
+    /**
+     * Flash a warning message.
+     */
+    public function warning(string $message): void
+    {
+        $this->message($message, 'warning');
+    }
+}

--- a/packages/flash/src/FlashServiceProvider.php
+++ b/packages/flash/src/FlashServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laracasts\Flash;
+
+use Illuminate\Support\ServiceProvider;
+
+class FlashServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        $this->app->singleton('flash', function ($app) {
+            return new FlashNotifier($app['session']);
+        });
+    }
+
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot(): void
+    {
+        $this->loadViewsFrom(resource_path('views/vendor/flash'), 'flash');
+    }
+}

--- a/resources/views/vendor/flash/message.blade.php
+++ b/resources/views/vendor/flash/message.blade.php
@@ -1,0 +1,6 @@
+@if(session()->has('flash_notification'))
+    @php($flash = session('flash_notification'))
+    <div class="alert alert-{{ $flash['level'] }}">
+        {{ $flash['message'] }}
+    </div>
+@endif


### PR DESCRIPTION
## Summary
- Provide in-repo `Laracasts\Flash` classes and view to resolve missing `FlashServiceProvider`
- Autoload custom flash classes via Composer classmap

## Testing
- `composer dump-autoload` *(fails: Class "Illuminate\Foundation\Application" not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf49b1f36c83269ae76b8098b5ec3b