### PR TITLE
fix: autoload flash service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,11 +61,9 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
-        },
-        "classmap": [
-            "packages/flash/src"
-        ]
+            "Database\\Seeders\\": "database/seeders/",
+            "Laracasts\\Flash\\": "packages/flash/src/"
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- map `Laracasts\Flash` namespace to local flash package

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: lock file cannot be installed, requires php ~8.0.0|~8.1.0|~8.2.0|~8.3.0; your php 8.4.12 does not satisfy)*
- `composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4b3b1d148326bf52415930bdb85d