### PR TITLE
Remove InfyOm generator dependency

### DIFF
--- a/app/Http/Controllers/API/AuthAPIController.php
+++ b/app/Http/Controllers/API/AuthAPIController.php
@@ -15,7 +15,7 @@ use Hash;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use InfyOm\Generator\Utils\ResponseUtil;
+use App\Utils\ResponseUtil;
 
 class AuthAPIController extends AppBaseController
 {

--- a/app/Http/Controllers/AppBaseController.php
+++ b/app/Http/Controllers/AppBaseController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use InfyOm\Generator\Utils\ResponseUtil;
+use App\Utils\ResponseUtil;
 use Response;
 
 /**

--- a/app/Http/Middleware/CheckUserIsActivated.php
+++ b/app/Http/Middleware/CheckUserIsActivated.php
@@ -9,7 +9,7 @@ use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use InfyOm\Generator\Utils\ResponseUtil;
+use App\Utils\ResponseUtil;
 use Session;
 
 class CheckUserIsActivated

--- a/app/Utils/ResponseUtil.php
+++ b/app/Utils/ResponseUtil.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Utils;
+
+class ResponseUtil
+{
+    /**
+     * Prepare a success response structure.
+     */
+    public static function makeResponse(string $message, $data): array
+    {
+        return ['success' => true, 'message' => $message, 'data' => $data];
+    }
+
+    /**
+     * Prepare an error response structure.
+     */
+    public static function makeError(string $message, array $errors = []): array
+    {
+        $response = ['success' => false, 'message' => $message];
+
+        if (!empty($errors)) {
+            $response['errors'] = $errors;
+        }
+
+        return $response;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Facade;
 // use InfyOm\CoreUITemplates\CoreUITemplatesServiceProvider;
-use InfyOm\Generator\InfyOmGeneratorServiceProvider;
 
 return [
 
@@ -194,7 +193,6 @@ return [
          * Package Service Providers...
          */
         Laracasts\Flash\FlashServiceProvider::class,
-        InfyOmGeneratorServiceProvider::class,
         // CoreUITemplatesServiceProvider::class,
         Yajra\DataTables\DataTablesServiceProvider::class,
         Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,


### PR DESCRIPTION
## Summary
- Remove InfyOm generator service provider from application config
- Replace uses of InfyOm ResponseUtil with a local implementation

## Testing
- `php -l app/Utils/ResponseUtil.php app/Http/Controllers/AppBaseController.php app/Http/Middleware/CheckUserIsActivated.php app/Http/Controllers/API/AuthAPIController.php config/app.php`
- `composer install` *(failed: requires php ~8.0-8.3 and ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4e70b59083269174d16dc6b24583