### PR TITLE
Fix Spatie permission middleware namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,9 +63,9 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'user.activated' => CheckUserIsActivated::class,
-        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
-        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
         'sendMessage' => SendMessage::class,
     ];
 }


### PR DESCRIPTION
## Summary
- update Spatie permission middleware namespaces to match package path

## Testing
- `composer install --ignore-platform-req=php --ignore-platform-req=ext-sodium` *(fails: CONNECT tunnel failed, response 403)*
- `php -l app/Http/Kernel.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf500b07a0832694112ea3efc73584