### PR TITLE
fix: update Livewire directives to v3 syntax

### DIFF
--- a/resources/views/chat/group_members_modal.blade.php
+++ b/resources/views/chat/group_members_modal.blade.php
@@ -11,7 +11,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                @livewire('search-group-members-for-edit-group')
+                <livewire:search-group-members-for-edit-group />
                 <button class="btn btn-primary mt-1 btn-add-members-to-group mt-3" data-group-id=""
                         data-loading-text="<span class='spinner-border spinner-border-sm'></span> Processing...">
                     {{__('messages.chats.add_to_group')}}

--- a/resources/views/chat/group_modals.blade.php
+++ b/resources/views/chat/group_modals.blade.php
@@ -83,7 +83,7 @@
                     <div class="col-sm-12">
                         {!! Form::label('users', __('messages.group.members'),['class' => 'login-group__sub-title']).":" !!}
                         <span class="red">*</span>
-                        @livewire('search-group-members-for-create-group')
+                        <livewire:search-group-members-for-create-group />
                     </div>
                 </div>
                 <div class="row mt-2">

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -152,19 +152,19 @@
                         <div class="tab-content search-any-member mt-3" id="nav-tabContent">
                             <div class="tab-pane fade show active" id="nav-my-contacts" role="tabpanel"
                                  aria-labelledby="nav-my-contacts-tab">
-                                @livewire('my-contacts-search', ['myContactIds' => $myContactIds, 'blockUserIds' => $blockUserIds])
+                                <livewire:my-contacts-search :my-contact-ids="$myContactIds" :block-user-ids="$blockUserIds" />
                             </div>
                             <div class="tab-pane fade" id="nav-users" role="tabpanel" aria-labelledby="nav-users-tab">
-                                @livewire('search-users', ['myContactIds' => $myContactIds, 'blockUserIds' => $blockUserIds])
+                                <livewire:search-users :my-contact-ids="$myContactIds" :block-user-ids="$blockUserIds" />
                             </div>
                             @if($enableGroupSetting == 1)
                             <div class="tab-pane fade" id="nav-groups" role="tabpanel" aria-labelledby="nav-groups-tab">
-                                @livewire('group-search')
+                                <livewire:group-search />
                             </div>
                             @endif
                             <div class="tab-pane fade show" id="nav-blocked-users" role="tabpanel"
                                  aria-labelledby="nav-blocked-users-tab">
-                                @livewire('blocked-user-search', ['blockedByMeUserIds' => $blockedByMeUserIds])
+                                <livewire:blocked-user-search :blocked-by-me-user-ids="$blockedByMeUserIds" />
                             </div>
                         </div>
                     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
     @if(getLoggedInUser()->is_subscribed)
         @include('layouts.one_signal')
     @endif
-    @livewireStyles
+    <livewire:styles />
     @routes
     <link rel="stylesheet" href="{{ mix('assets/css/font-awesome.css') }}">
     <link rel="stylesheet" href="{{ asset('css/emojionearea.min.css') }}">
@@ -208,7 +208,7 @@
 <script src="{{ mix('assets/js/set_user_status.js') }}"></script>
 <script src="{{ mix('assets/js/set-user-on-off.js') }}"></script>
 <script src="{{mix('assets/js/profile.js')}}"></script>
-@livewireScripts
+<livewire:scripts />
 @stack('scripts')
 @yield('scripts')
 </html>


### PR DESCRIPTION
## Summary
- replace `@livewire` directives with `<livewire:...>` tags in chat views
- update layout to use `<livewire:styles />` and `<livewire:scripts />`

## Testing
- `php artisan optimize:clear` *(fails: Failed to open stream: No such file or directory)*
- `composer install` *(fails: requires php ~8.0-8.3 & ext-sodium)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf50f499ac8326875d0a58d5a2dbfe