### PR TITLE
Fix Livewire component namespace for discovery

### DIFF
--- a/app/Livewire/BlockedUserSearch.php
+++ b/app/Livewire/BlockedUserSearch.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Contracts\Foundation\Application;

--- a/app/Livewire/GroupSearch.php
+++ b/app/Livewire/GroupSearch.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\Group;
 use Illuminate\Contracts\Foundation\Application;

--- a/app/Livewire/MyContactsSearch.php
+++ b/app/Livewire/MyContactsSearch.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Contracts\Foundation\Application;

--- a/app/Livewire/SearchGroupMembersForCreateGroup.php
+++ b/app/Livewire/SearchGroupMembersForCreateGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Contracts\Foundation\Application;

--- a/app/Livewire/SearchGroupMembersForEditGroup.php
+++ b/app/Livewire/SearchGroupMembersForEditGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;

--- a/app/Livewire/SearchUsers.php
+++ b/app/Livewire/SearchUsers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Contracts\Foundation\Application;


### PR DESCRIPTION
## Summary
- Move Livewire components to `App\Livewire` namespace to match Livewire v3

## Testing
- `php -l app/Livewire/BlockedUserSearch.php app/Livewire/MyContactsSearch.php app/Livewire/SearchUsers.php app/Livewire/GroupSearch.php app/Livewire/SearchGroupMembersForCreateGroup.php app/Livewire/SearchGroupMembersForEditGroup.php`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: package requirements not satisfied for php version and ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5320243c8326aceae1299b54c974