### PR TITLE
Fix Role findById signature for Spatie contract compatibility

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -136,7 +136,7 @@ class Role extends Model implements RoleContract
         return $role;
     }
 
-    public static function findById(int $id, $guardName = null): RoleContract
+    public static function findById(int|string $id, ?string $guardName = null): RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 


### PR DESCRIPTION
## Summary
- align Role::findById with Spatie\Permission contract by accepting int|string id and nullable guard name

## Testing
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit not found)*
- `composer install --no-interaction --no-progress` *(fails: requires PHP ~8.0-8.3 and ext-sodium; environment uses 8.4 and lacks extension)*
- `composer install --no-interaction --no-progress --ignore-platform-req=php --ignore-platform-req=ext-sodium` *(fails: repeated 403 responses when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5448dae48326a62a179fd7c3d541