### PR TITLE
Fix Laravel bootstrap to build application

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,4 +16,5 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    });
+    })
+    ->create();


### PR DESCRIPTION
## Summary
- finalize application configuration with `->create()` in `bootstrap/app.php`

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: laminas/laminas-diactoros requires php ~8.3, ext-sodium missing)*
- `php -l bootstrap/app.php`


------
https://chatgpt.com/codex/tasks/task_b_68bf54b46d00832e8db7a28b340cdfc8