### PR TITLE
Ensure Laravel bootstrap returns configured application

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,4 +16,5 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    });
+    })
+    ->create();


### PR DESCRIPTION
## Summary
- call `->create()` on application builder so Laravel returns an `Application` instance

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: laminas/laminas-diactoros requires php ~8.0-8.3 and ext-sodium is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf551d17288326a7944592c222d3f9