### PR TITLE
fix missing APIRequest class

### DIFF
--- a/app/Http/Requests/UpdateUserNotificationRequest.php
+++ b/app/Http/Requests/UpdateUserNotificationRequest.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Requests;
 
-use InfyOm\Generator\Request\APIRequest;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class UpdateUserNotificationRequest
  */
-class UpdateUserNotificationRequest extends APIRequest
+class UpdateUserNotificationRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
## Summary
- replace missing InfyOm APIRequest with Laravel FormRequest in UpdateUserNotificationRequest

## Testing
- `composer install` *(fails: Your lock file does not contain a compatible set of packages. ... requires php ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.12) does not satisfy that requirement)*


------
https://chatgpt.com/codex/tasks/task_b_68bf56eadcfc832e997a440f97a5e93f