### PR TITLE
Fix user activation middleware resolution

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,6 @@
 
 namespace App\Http;
 
-use App\Http\Middleware\CheckUserIsActivated;
 use App\Http\Middleware\SendMessage;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -62,7 +61,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'user.activated' => CheckUserIsActivated::class,
         'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
         'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
         'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\API\UserAPIController;
 use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Middleware\CheckUserIsActivated;
 
 /*
 |--------------------------------------------------------------------------
@@ -34,7 +35,7 @@ Route::post('password/reset', [PasswordResetController::class, 'sendResetPasswor
 Route::post('password/update', [PasswordResetController::class, 'reset']);
 Route::get('activate', [AuthAPIController::class, 'verifyAccount']);
 
-Route::middleware(['auth:api', 'user.activated'])->group(function () {
+Route::middleware(['auth:api', CheckUserIsActivated::class])->group(function () {
     Route::post('broadcasting/auth', [BroadcastController::class, 'authenticate']);
     Route::get('logout', [AuthAPIController::class, 'logout']);
 
@@ -62,7 +63,7 @@ Route::middleware(['auth:api', 'user.activated'])->group(function () {
     Route::post('social-login/{provider}', [SocialAuthAPIController::class, 'socialLogin'])->middleware('web');
 });
 
-Route::middleware(['role:Admin', 'auth:api', 'user.activated'])->group(function () {
+Route::middleware(['role:Admin', 'auth:api', CheckUserIsActivated::class])->group(function () {
     Route::resource('users', AdminUsersAPIController::class);
     Route::post('users/{user}/update', [AdminUsersAPIController::class, 'update']);
     Route::post('users/{user}/active-de-active', [AdminUsersAPIController::class, 'activeDeActiveUser'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FrontCMSController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Middleware\CheckUserIsActivated;
 
 /*
 |--------------------------------------------------------------------------
@@ -39,7 +40,7 @@ Route::post('update-language', [UserController::class, 'updateLanguage'])->middl
 Route::get('/users/impersonate-logout',
     [UserController::class, 'userImpersonateLogout'])->name('impersonate.userLogout');
 
-Route::middleware(['user.activated', 'auth'])->group(function () {
+Route::middleware([CheckUserIsActivated::class, 'auth'])->group(function () {
     //view routes
     Route::get('/conversations',
         [ChatController::class, 'index'])->name('conversations')->middleware('permission:manage_conversations');
@@ -114,7 +115,7 @@ Route::middleware(['user.activated', 'auth'])->group(function () {
 });
 
 // users
-Route::middleware(['permission:manage_users', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_users', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::resource('users', UserController::class);
     Route::post('users/{user}/active-de-active', [UserController::class, 'activeDeActiveUser'])
         ->name('active-de-active-user');
@@ -126,24 +127,24 @@ Route::middleware(['permission:manage_users', 'auth', 'user.activated'])->group(
 });
 
 // roles
-Route::middleware(['permission:manage_roles', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_roles', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::resource('roles', RoleController::class)->except('update');
     Route::post('roles/{role}/update', [RoleController::class, 'update'])->name('roles.update');
 });
 
 // settings
-Route::middleware(['permission:manage_settings', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_settings', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::get('settings', [SettingsController::class, 'index'])->name('settings.index');
     Route::post('settings', [SettingsController::class, 'update'])->name('settings.update');
 });
 
 // reported-users
-Route::middleware(['permission:manage_reported_users', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_reported_users', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::resource('reported-users', ReportUserController::class);
 });
 
 // meetings
-Route::middleware(['permission:manage_meetings', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_meetings', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::resource('meetings', MeetingController::class);
     Route::get('meetings/{meeting}/change-status/{status}',
         [MeetingController::class, 'changeMeetingStatus'])->name('meeting.change-meeting-status');
@@ -155,7 +156,7 @@ Route::middleware('web')->group(function () {
     Route::get('login/{provider}/callback', [SocialAuthController::class, 'callback']);
 });
 
-Route::middleware(['permission:manage_front_cms', 'auth', 'user.activated'])->group(function () {
+Route::middleware(['permission:manage_front_cms', 'auth', CheckUserIsActivated::class])->group(function () {
     Route::get('front-cms', [FrontCMSController::class, 'frontCms'])->name('front.cms');
     Route::post('front-cms', [FrontCMSController::class, 'updateFrontCms'])->name('front.cms.update');
 });


### PR DESCRIPTION
## Summary
- Replace `user.activated` middleware alias with direct `CheckUserIsActivated` reference in web and API routes
- Drop unused `user.activated` alias from Kernel

## Testing
- `composer install` *(fails: laminas/laminas-diactoros requires php ~8.0-~8.3; lcobucci/jwt requires ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68bf59273e0483269c8337946aba4073