### PR TITLE
Fix permission middleware namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,9 +61,9 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
-        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
         'sendMessage' => SendMessage::class,
     ];
 }


### PR DESCRIPTION
## Summary
- fix Spatie permission middleware registration in Kernel

## Testing
- `php -l app/Http/Kernel.php`
- `composer install` (fails: requires PHP ~8.0-8.3 and ext-sodium, network 403)


------
https://chatgpt.com/codex/tasks/task_b_68bf5a3f1608832ea7357a622d6eacd9