### PR TITLE
Register permission middleware

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,10 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\SendMessage;
+use Spatie\Permission\Middlewares\RoleMiddleware;
+use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,7 +16,12 @@ return Application::configure(basePath: dirname(__DIR__))
         channels: __DIR__.'/../routes/channels.php',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => RoleMiddleware::class,
+            'permission' => PermissionMiddleware::class,
+            'role_or_permission' => RoleOrPermissionMiddleware::class,
+            'sendMessage' => SendMessage::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
## Summary
- register permission and related middleware aliases in the Laravel 11 bootstrap file

## Testing
- `php -l bootstrap/app.php`
- `php -l app/Http/Middleware/CheckUserIsActivated.php`
- `composer install --no-interaction --no-progress --no-scripts` *(fails: Failed to open stream / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68bf5b6462e0832ea4d2ce8ef94e047a