### PR TITLE
Use plain labels in auth views

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -35,7 +35,7 @@
                                 </div>
                                 <p class="text-muted login-group__sub-title mb-4 text-center">{{ __('messages.sign_in_to_your_account') }}</p>
                                 <div class="form-group mb-4 login-group__sub-title">
-                                    {!! Form::label('email', __('messages.email').':' )!!}<span class="red">*</span>
+                                    <label for="email">{{ __('messages.email') }}:</label><span class="red">*</span>
                                     <input type="email"
                                            class="form-control login-group__input"
                                            name="email"
@@ -44,7 +44,7 @@
                                            id="email" required>
                                 </div>
                                 <div class="form-group mb-4 login-group__sub-title">
-                                    {!! Form::label('password', __('messages.password').':' ) !!}<span
+                                    <label for="password">{{ __('messages.password') }}:</label><span
                                             class="red">*</span>
                                     <input type="password"
                                            class="form-control login-group__input"

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -22,21 +22,21 @@
                             <h1 class="login-group__title mb-2">{{ __('messages.register') }}</h1>
                             <p class="text-muted login-group__sub-title mb-3">{{ __('messages.create_your_account') }}</p>
                             <div class="form-group mb-4 login-group__sub-title">
-                                {!! Form::label('name', __('messages.full_name').':' )!!}<span class="red">*</span>
+                                <label for="name">{{ __('messages.full_name') }}:</label><span class="red">*</span>
                                 <input type="text"
                                        class="form-control login-group__input"
                                        name="name" value="{{ old('name') }}"
                                        placeholder="{{ __('messages.full_name') }}" id="name" required>
                             </div>
                             <div class="form-group mb-4 login-group__sub-title">
-                                {!! Form::label('email', __('messages.email').':' )!!}<span class="red">*</span>
+                                <label for="email">{{ __('messages.email') }}:</label><span class="red">*</span>
                                 <input type="email"
                                        class="form-control login-group__input"
                                        name="email" value="{{ old('email') }}" placeholder="{{ __('messages.email') }}"
                                        id="email" required>
                             </div>
                             <div class="form-group mb-4 login-group__sub-title">
-                                {!! Form::label('password', __('messages.password').':' )!!}<span class="red">*</span>
+                                <label for="password">{{ __('messages.password') }}:</label><span class="red">*</span>
                                 <i class="fa fa-question-circle ms-2 question-type-open cursor-pointer"
                                    data-bs-toggle="tooltip" data-bs-placement="top"
                                    title="Minimum 8 character required, White space is not allowed"></i>
@@ -46,7 +46,7 @@
                                        onkeypress="return avoidSpace(event)" required>
                             </div>
                             <div class="form-group mb-4 login-group__sub-title">
-                                {!! Form::label('confirm_password', __('messages.confirm_password').':' )!!}<span
+                                <label for="password_confirmation">{{ __('messages.confirm_password') }}:</label><span
                                     class="red">*</span>
                                 <i class="fa fa-question-circle ms-2 question-type-open cursor-pointer"
                                    data-bs-toggle="tooltip" data-bs-placement="top"


### PR DESCRIPTION
## Summary
- replace Form facade usage with standard `<label>` tags in auth login and register views

## Testing
- `composer install --no-progress --no-scripts` *(fails: laminas-diactoros requires PHP ~8.0-8.3; ext-sodium missing)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5c5b2f848326aeeb8e44eea46460