### PR TITLE
fix: update Spatie middleware namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,9 +61,9 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
-        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
         'sendMessage' => SendMessage::class,
     ];
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,9 +4,9 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use App\Http\Middleware\SendMessage;
-use Spatie\Permission\Middlewares\RoleMiddleware;
-use Spatie\Permission\Middlewares\PermissionMiddleware;
-use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(


### PR DESCRIPTION
## Summary
- correct Spatie permission middleware imports for Laravel 11
- fix kernel middleware aliases to new namespace

## Testing
- `composer install` *(fails: laminas/laminas-diactoros requires php ~8.3; lcobucci/jwt requires ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_b_68bf5d1bd3c8832eb1aa61de5f4686c8