### PR TITLE
Remove coreui template dependency

### DIFF
--- a/config/infyom/laravel_generator.php
+++ b/config/infyom/laravel_generator.php
@@ -89,7 +89,7 @@ return [
     |
     */
 
-    'templates' => 'coreui-templates',
+    'templates' => 'infyom-generator-templates',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/layouts/errors.blade.php
+++ b/resources/views/layouts/errors.blade.php
@@ -1,0 +1,9 @@
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/meetings/create.blade.php
+++ b/resources/views/meetings/create.blade.php
@@ -18,7 +18,7 @@
                             </div>
                         </div>
                         <div class="card-body">
-                            @include('coreui-templates::common.errors')
+                            @include('layouts.errors')
                             <form method="post" action="{{ route('meetings.store') }}" id="meetingForm">
                                 {{ csrf_field() }}
                                 <div class="row">

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -18,7 +18,7 @@
                             </div>
                         </div>
                         <div class="card-body">
-                            @include('coreui-templates::common.errors')
+                            @include('layouts.errors')
                                 {{ Form::model($meeting, ['route' => ['meetings.update', $meeting->id], 'method' => 'put', 'id'=>'meetingForm']) }}
                                 {{ csrf_field() }}
                                 <div class="row">

--- a/resources/views/roles/create.blade.php
+++ b/resources/views/roles/create.blade.php
@@ -18,7 +18,7 @@
                             </div>
                         </div>
                         <div class="card-body py-sm-3 py-1">
-                            @include('coreui-templates::common.errors')
+                            @include('layouts.errors')
                             {{ Form::open(['id'=>'createRoleForm', 'route' => 'roles.store', 'method' => 'post']) }}
                                 {{ csrf_field() }}
                                 <div class="row mb-sm-0 mb-1">

--- a/resources/views/roles/edit.blade.php
+++ b/resources/views/roles/edit.blade.php
@@ -18,7 +18,7 @@
                             </div>
                         </div>
                         <div class="card-body py-sm-3 py-1">
-                            @include('coreui-templates::common.errors')
+                            @include('layouts.errors')
                             {{ Form::model($role, ['route' => ['roles.update', $role->id], 'method' => 'post', 'id' => 'editRoleForm']) }}
                             {{ csrf_field() }}
                             <div class="row mb-sm-0 mb-1">


### PR DESCRIPTION
## Summary
- replace missing coreui error include with local `layouts.errors` partial in meeting and role forms
- add reusable errors view
- use local infyom generator templates instead of coreui templates

## Testing
- ⚠️ `php artisan test` *(failed: Missing vendor/autoload)*
- ⚠️ `composer install` *(failed: laminas/laminas-diactoros requires php ~8.0-8.3; ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_b_68bf84043cf4832eb5fe916469921df5