### PR TITLE
Allow Form::select to accept collections

### DIFF
--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use Illuminate\Support\Collection;
 use function csrf_field;
 use function route;
 use function url;
@@ -114,7 +115,7 @@ class Form
             .'</textarea>';
     }
 
-    public static function select(string $name, array $list = [], $selected = null, array $options = []): string
+    public static function select(string $name, array|Collection $list = [], $selected = null, array $options = []): string
     {
         $attr = self::attributes($options);
         $multiple = isset($options['multiple']) || in_array('multiple', $options, true);


### PR DESCRIPTION
## Summary
- Allow `Form::select` to accept arrays or collections

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install --no-interaction --no-progress` *(fails: requires ext-sodium and PHP 8.2)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68bf854b7b2c832e8bca4fd09cfd0364