### PR TITLE
Allow creating roles without permissions

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -96,7 +96,7 @@ class Role extends Model implements RoleContract
      */
     public static $rules = [
         'name' => 'required',
-        'permissions' => 'required',
+        'permissions' => 'nullable|array',
     ];
 
     /**

--- a/resources/views/roles/edit_fields.blade.php
+++ b/resources/views/roles/edit_fields.blade.php
@@ -6,7 +6,7 @@
     {{ Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'edit_role_name', 'required','placeholder'=>__('messages.name')]) }}
 </div>
 <div class="form-group col-md-6 col-sm-12">
-{{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}<span class="red">*</span>
+{{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
 <br>
 <div class="row px-3">
     @foreach($permissions->get() as $permission)

--- a/resources/views/roles/fields.blade.php
+++ b/resources/views/roles/fields.blade.php
@@ -6,7 +6,7 @@
     {{ Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'role_name', 'required','placeholder'=>__('messages.name')]) }}
 </div>
 <div class="form-group col-md-6 col-sm-12">
-    {{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}<span class="red">*</span>
+    {{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
     <br>
     <div class="row px-3">
         @foreach($permissions->get() as $permission)


### PR DESCRIPTION
## Summary
- Make role permissions optional to avoid errors when creating roles without any permissions
- Remove required marker from role forms

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required '/workspace/laravel-InfyChat/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bf85e68a4483268deb0f00bef93acf