### PR TITLE
Fix meeting save button JS error

### DIFF
--- a/resources/assets/js/admin/meetings/meetings.js
+++ b/resources/assets/js/admin/meetings/meetings.js
@@ -27,9 +27,8 @@ $('.time-zone').select2({
 $('#meetingForm').on('submit', function (event) {
     event.preventDefault();
     let loadingButton = jQuery(this).find('#btnSave');
-    loadingButton.button('loading');
+    loadingButton.prop('disabled', true);
+    loadingButton.html(loadingButton.data('loading-text'));
 
     $('#meetingForm')[0].submit();
-
-    return true;
 });


### PR DESCRIPTION
## Summary
- prevent meeting save button from calling missing Bootstrap loading plugin

## Testing
- `npm test` *(fails: Missing script "test" - no tests defined)*
- `composer install --ignore-platform-reqs` *(fails: composer could not download packages due to GitHub API restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68bf865be464832ea229af8b8f08d31e