### PR TITLE
Localize loading text in chat modals

### DIFF
--- a/resources/views/chat/copyImageModal.blade.php
+++ b/resources/views/chat/copyImageModal.blade.php
@@ -15,8 +15,8 @@
                     {{__('messages.chats.cancel')}}
                 </button>
                 <button class="btn btn-success me-1 pull-right mt-3" data-group-id="" id="sendImages"
-                        data-loading-text="<span class='spinner-border spinner-border-sm'></span> Processing...">
-                    {{__('messages.chats.send')}}
+                        data-loading-text="<span class='spinner-border spinner-border-sm'></span> {{ __('messages.processing') }}">
+                    {{ __('messages.chats.send') }}
                 </button>
             </div>
         </div>

--- a/resources/views/chat/edit_group_modals.blade.php
+++ b/resources/views/chat/edit_group_modals.blade.php
@@ -79,7 +79,7 @@
                 </div>
                 <div class="row mt-3">
                     <div class="col-sm-12 text-start">
-                        {!! Form::button(__('messages.save'), ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnEditGroup','data-loading-text' => "<span class='spinner-border spinner-border-sm'></span> Processing..."]) !!}
+                        {!! Form::button(__('messages.save'), ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnEditGroup','data-loading-text' => "<span class='spinner-border spinner-border-sm'></span> " . __('messages.processing')]) !!}
                         <button type="button" class="btn btn-secondary ms-1"
                                 data-bs-dismiss="modal">{{ __('messages.chats.cancel') }}
                         </button>

--- a/resources/views/chat/group_members_modal.blade.php
+++ b/resources/views/chat/group_members_modal.blade.php
@@ -13,8 +13,8 @@
             <div class="modal-body">
                 <livewire:search-group-members-for-edit-group />
                 <button class="btn btn-primary mt-1 btn-add-members-to-group mt-3" data-group-id=""
-                        data-loading-text="<span class='spinner-border spinner-border-sm'></span> Processing...">
-                    {{__('messages.chats.add_to_group')}}
+                        data-loading-text="<span class='spinner-border spinner-border-sm'></span> {{ __('messages.processing') }}">
+                    {{ __('messages.chats.add_to_group') }}
                 </button>
             </div>
         </div>

--- a/resources/views/chat/group_modals.blade.php
+++ b/resources/views/chat/group_modals.blade.php
@@ -88,7 +88,7 @@
                 </div>
                 <div class="row mt-2">
                     <div class="col-sm-12 text-start">
-                        {!! Form::button(__('messages.save'), ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnCreateGroup','data-loading-text' => "<span class='spinner-border spinner-border-sm'></span> Processing..."]) !!}
+                        {!! Form::button(__('messages.save'), ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnCreateGroup','data-loading-text' => "<span class='spinner-border spinner-border-sm'></span> " . __('messages.processing')]) !!}
                         <button type="button" id="btnCancel" class="btn btn-secondary ms-1 "
                                 data-bs-dismiss="modal">{{ __('messages.cancel') }}
                         </button>

--- a/resources/views/chat/report_user_modal.blade.php
+++ b/resources/views/chat/report_user_modal.blade.php
@@ -22,8 +22,8 @@
                         {{__('messages.cancel')}}
                     </button>
                     <button class="btn btn-primary me-1 pull-right" data-group-id="" id="reportUser"
-                            data-loading-text="<span class='spinner-border spinner-border-sm'></span> Processing...">
-                        {{__('messages.report')}}
+                            data-loading-text="<span class='spinner-border spinner-border-sm'></span> {{ __('messages.processing') }}">
+                        {{ __('messages.report') }}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- use translation helper for Processing... spinner text in chat-related modals

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: platform requirements for PHP extension sodium and version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf875827b483269aca91379f5cae14