### PR TITLE
Fix missing permissions on role form

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -48,7 +48,7 @@ class RoleController extends AppBaseController
      */
     public function create()
     {
-        $permissions = Permission::toBase();
+        $permissions = Permission::orderBy('display_name')->get();
 
         return view('roles.create', compact('permissions'));
     }
@@ -87,7 +87,7 @@ class RoleController extends AppBaseController
         if ($role->is_default) {
             return redirect()->back();
         }
-        $permissions = Permission::toBase();
+        $permissions = Permission::orderBy('display_name')->get();
 
         return view('roles.edit', compact('permissions', 'role'));
     }

--- a/resources/views/roles/edit_fields.blade.php
+++ b/resources/views/roles/edit_fields.blade.php
@@ -9,7 +9,7 @@
 {{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
 <br>
 <div class="row px-3">
-    @foreach($permissions->get() as $permission)
+    @foreach($permissions as $permission)
         <div class="custom-control custom-checkbox mb-2">
             <input id="{{ $permission->name }}" class="custom-control-input not-checkbox role-permission"
                    type="checkbox" name="permissions[]"

--- a/resources/views/roles/fields.blade.php
+++ b/resources/views/roles/fields.blade.php
@@ -9,7 +9,7 @@
     {{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
     <br>
     <div class="row px-3">
-        @foreach($permissions->get() as $permission)
+        @foreach($permissions as $permission)
             <div class="custom-control custom-checkbox mb-2">
                 <input id="{{ $permission->name }}" class="custom-control-input not-checkbox role-permission"
                        type="checkbox" name="permissions[]"


### PR DESCRIPTION
## Summary
- load permission collection when rendering role forms
- iterate over permissions list in role form views

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: PHP 8.4 incompatible & ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_b_68bf87e652bc832ebcb64a403d713631