### PR TITLE
Fix meeting save button markup to avoid HTML encoding

### DIFF
--- a/resources/views/meetings/fields.blade.php
+++ b/resources/views/meetings/fields.blade.php
@@ -66,7 +66,9 @@
 </div>
 
 <div class="form-group col-sm-12 mb-0">
-    {{ Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary me-1','id'=>'btnSave','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) }}
-    <a href="{{ route('meetings.index') }}"
-            class="btn btn-secondary">{{ __('messages.cancel') }}</a>
+    <button type="submit" class="btn btn-primary me-1" id="btnSave"
+            data-loading-text="<span class='spinner-border spinner-border-sm'></span> {{ __('messages.processing') }}">
+        {{ __('messages.save') }}
+    </button>
+    <a href="{{ route('meetings.index') }}" class="btn btn-secondary">{{ __('messages.cancel') }}</a>
 </div>


### PR DESCRIPTION
## Summary
- replace Form::button with standard HTML button on meeting form

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: Your lock file does not contain a compatible set of packages; ext-sodium missing)*
- `composer install --no-interaction --no-progress --ignore-platform-reqs` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bf897d41288326be5011090e269a01