### PR TITLE
Fix role form rendering

### DIFF
--- a/resources/views/roles/create.blade.php
+++ b/resources/views/roles/create.blade.php
@@ -19,13 +19,12 @@
                         </div>
                         <div class="card-body py-sm-3 py-1">
                             @include('layouts.errors')
-                            {{ Form::open(['id'=>'createRoleForm', 'route' => 'roles.store', 'method' => 'post']) }}
-                                {{ csrf_field() }}
+                            {!! Form::open(['id' => 'createRoleForm', 'route' => 'roles.store', 'method' => 'post']) !!}
                                 <div class="row mb-sm-0 mb-1">
                                     @include('roles.fields')
                                 </div>
 
-                            {{ Form::close() }}
+                            {!! Form::close() !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/roles/edit.blade.php
+++ b/resources/views/roles/edit.blade.php
@@ -19,13 +19,12 @@
                         </div>
                         <div class="card-body py-sm-3 py-1">
                             @include('layouts.errors')
-                            {{ Form::model($role, ['route' => ['roles.update', $role->id], 'method' => 'post', 'id' => 'editRoleForm']) }}
-                            {{ csrf_field() }}
+                            {!! Form::model($role, ['route' => ['roles.update', $role->id], 'method' => 'post', 'id' => 'editRoleForm']) !!}
                             <div class="row mb-sm-0 mb-1">
                                 @include('roles.edit_fields')
                             </div>
 
-                            {{ Form::close() }}
+                            {!! Form::close() !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/roles/edit_fields.blade.php
+++ b/resources/views/roles/edit_fields.blade.php
@@ -2,11 +2,11 @@
     <div class="alert alert-danger form-group col-sm-12" style="display: none" id="editValidationErrorsBox"></div>
 </div>
 <div class="form-group col-md-6 col-sm-12 login-group__sub-title">
-    {{ Form::label('name', __('messages.name').':') }}<span class="red">*</span>
-    {{ Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'edit_role_name', 'required','placeholder'=>__('messages.name')]) }}
+    {!! Form::label('name', __('messages.name').':') !!}<span class="red">*</span>
+    {!! Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'edit_role_name', 'required','placeholder'=>__('messages.name')]) !!}
 </div>
 <div class="form-group col-md-6 col-sm-12">
-{{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
+ {!! Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) !!}
 <br>
 <div class="row px-3">
     @foreach($permissions as $permission)
@@ -20,7 +20,7 @@
 </div>
 </div>
 <div class="text-start form-group col-sm-12">
-    {{ Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnEditSave','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) }}
+    {!! Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary','id'=>'btnEditSave','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) !!}
     <a type="button" href="{{ route('roles.index') }}" id="btnCancelEdit"
        class="btn btn-secondary close_edit_role ms-1">{{ __('messages.cancel') }}
     </a>

--- a/resources/views/roles/fields.blade.php
+++ b/resources/views/roles/fields.blade.php
@@ -2,11 +2,11 @@
     <div class="alert alert-danger" style="display: none" id="validationErrorsBox"></div>
 </div>
 <div class="form-group col-md-6 col-sm-12 login-group__sub-title">
-    {{ Form::label('name', __('messages.name').':') }}<span class="red">*</span>
-    {{ Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'role_name', 'required','placeholder'=>__('messages.name')]) }}
+    {!! Form::label('name', __('messages.name').':') !!}<span class="red">*</span>
+    {!! Form::text('name', null, ['class' => 'form-control login-group__input', 'id' => 'role_name', 'required','placeholder'=>__('messages.name')]) !!}
 </div>
 <div class="form-group col-md-6 col-sm-12">
-    {{ Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) }}
+    {!! Form::label('permissions', __('messages.permissions').':', ['class' => 'login-group__sub-title']) !!}
     <br>
     <div class="row px-3">
         @foreach($permissions as $permission)
@@ -21,7 +21,7 @@
     </div>
 </div>
 <div class="text-start form-group col-sm-12">
-    {{ Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary primary-btn','id'=>'btnCreateRole','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) }}
+    {!! Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary primary-btn','id'=>'btnCreateRole','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) !!}
     <a type="button" href="{{ route('roles.index') }}" id="btnRoleCancel"
        class="btn btn-secondary close_create_role ms-1">{{ __('messages.cancel') }}
     </a>


### PR DESCRIPTION
## Summary
- render role creation form correctly by outputting unescaped HTML
- fix role edit view and shared form fields for proper HTML generation

## Testing
- `phpunit` *(fails: command not found)*
- `composer install --ignore-platform-reqs` *(fails: could not download symfony/polyfill-mbstring 403 without GitHub token)*

------
https://chatgpt.com/codex/tasks/task_b_68bf89390c5c832e995257be0ea7bf43