### PR TITLE
Fix button loading state across forms

### DIFF
--- a/resources/assets/js/custom.js
+++ b/resources/assets/js/custom.js
@@ -1,3 +1,29 @@
+/**
+ * Lightweight replacement for Bootstrap's deprecated jQuery button plugin.
+ * It toggles a loading state on buttons by swapping the HTML and disabling
+ * the element. Call with "loading" to show the loader and "reset" to revert.
+ */
+(function ($) {
+    $.fn.button = function (action) {
+        return this.each(function () {
+            const $self = $(this);
+            if (action === 'loading') {
+                const loadingText = $self.attr('data-loading-text');
+                if (loadingText) {
+                    $self.data('original-text', $self.html())
+                        .html(loadingText)
+                        .prop('disabled', true);
+                }
+            } else if (action === 'reset') {
+                const originalText = $self.data('original-text');
+                if (originalText) {
+                    $self.html(originalText).prop('disabled', false);
+                }
+            }
+        });
+    };
+}(jQuery));
+
 window.displayToastr = function (heading, icon, message) {
     $.toast({
         heading: heading,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -188,16 +188,6 @@
             'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content'),
         },
     });
-    (function ($) {
-        $.fn.button = function (action) {
-            if (action === 'loading' && this.data('loading-text')) {
-                this.data('original-text', this.html()).html(this.data('loading-text')).prop('disabled', true)
-            }
-            if (action === 'reset' && this.data('original-text')) {
-                this.html(this.data('original-text')).prop('disabled', false);
-            }
-        };
-    }(jQuery));
     $(document).ready(function () {
         $('.alert').delay(4000).slideUp(300);
     });


### PR DESCRIPTION
## Summary
- implement custom jQuery plugin to manage button loading/disabled state
- remove redundant inline script and rely on shared helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8b025e38832ea0566062f4904f01