### PR TITLE
Fix meeting description textarea rendering

### DIFF
--- a/resources/views/meetings/fields.blade.php
+++ b/resources/views/meetings/fields.blade.php
@@ -62,7 +62,7 @@
 
 <div class="form-group col-sm-12 login-group__sub-title">
     {!! Form::label('agenda',__('messages.meeting.description').':')!!}<span class="red">*</span>
-    {{ Form::textarea('agenda', null, ['class' => 'form-control login-group__input', 'required','placeholder'=>__('messages.meeting.description')]) }}
+    {!! Form::textarea('agenda', null, ['class' => 'form-control login-group__input', 'required','placeholder'=>__('messages.meeting.description')]) !!}
 </div>
 
 <div class="form-group col-sm-12 mb-0">


### PR DESCRIPTION
## Summary
- ensure meeting description textarea renders correctly

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8bbe0200832ea719804996346f3a