### PR TITLE
Fix loading spinner text decoding for Save buttons

### DIFF
--- a/resources/assets/js/custom.js
+++ b/resources/assets/js/custom.js
@@ -9,7 +9,13 @@
                 const $this = $(this);
                 if (action === 'loading') {
                     $this.data('original-text', $this.html());
-                    $this.html($this.data('loading-text')).prop('disabled', true);
+                    let loadingText = $this.data('loading-text');
+                    if (loadingText && loadingText.indexOf('&') !== -1) {
+                        const textarea = document.createElement('textarea');
+                        textarea.innerHTML = loadingText;
+                        loadingText = textarea.value;
+                    }
+                    $this.html(loadingText).prop('disabled', true);
                 } else if (action === 'reset') {
                     $this.html($this.data('original-text')).prop('disabled', false);
                 }


### PR DESCRIPTION
## Summary
- decode `data-loading-text` before showing spinner to prevent broken Save buttons

## Testing
- `composer install` *(fails: laminas/laminas-diactoros requires php ~8.0, ext-sodium missing)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8c15155c832ea004600073b5d7d3