### PR TITLE
Fix settings save button spinner markup

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -145,7 +145,9 @@
                                     </div>
                                 </div>
                                 <div class="form-group mt-3">
-                                    {{ Form::button(__('messages.save') , ['type'=>'submit','class' => 'btn btn-primary me-1','id'=>'btnSave','data-loading-text'=>"<span class='spinner-border spinner-border-sm'></span> " .__('messages.processing')]) }}
+                                    <button type="submit" class="btn btn-primary me-1" id="btnSave" data-loading-text="<span class='spinner-border spinner-border-sm'></span> {{ __('messages.processing') }}">
+                                        {{ __('messages.save') }}
+                                    </button>
                                 </div>
                             </form>
                         </div>


### PR DESCRIPTION
## Summary
- fix HTML for save button on settings page so spinner markup renders correctly

## Testing
- `composer install` *(fails: laminas/laminas-diactoros requires php ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0; lcobucci/jwt requires ext-sodium)*


------
https://chatgpt.com/codex/tasks/task_e_68bf8e46902c83268decfaff2f9c164b