### PR TITLE
fix: pass session store to flash notifier

### DIFF
--- a/packages/flash/src/FlashServiceProvider.php
+++ b/packages/flash/src/FlashServiceProvider.php
@@ -12,7 +12,10 @@ class FlashServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton('flash', function ($app) {
-            return new FlashNotifier($app['session']);
+            // The session binding resolves to the session manager which does not
+            // satisfy the type-hint of the flash notifier. Resolve the actual
+            // session store implementation instead.
+            return new FlashNotifier($app['session.store']);
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure flash notifier receives session store instead of session manager

## Testing
- `composer install` *(fails: php version 8.4 not satisfied; missing ext-sodium)*
- `composer install --ignore-platform-reqs` *(fails: requires GitHub token to download dependencies)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c02ed66854832ea99b01b0b6148244